### PR TITLE
Refactor Emacs AI helpers into synth module

### DIFF
--- a/nix/homeModule/emacs/README.md
+++ b/nix/homeModule/emacs/README.md
@@ -1,0 +1,81 @@
+# Emacs development loop
+
+This module wires Emacs into a "Codex-like" workflow that stays fully local to
+NixOS/Home-Manager while still giving you AI-assisted editing, repo-aware chat
+and patching, and the usual Magit/Forge Git tooling.
+
+## Prerequisites
+
+* **Secrets** – store your OpenAI-compatible key in pass as
+  `openai/api-key` or export `OPENAI_API_KEY` before launching Emacs.  The
+  `gptel` helpers read from pass automatically when available.
+* **Copilot** – authenticate once with `M-x copilot-login` and install the
+  language server with `M-x copilot-install-server` (Node.js is provided by the
+  module).
+* **Direnv** – add a project-local `.envrc` containing `use flake` (or your
+  preferred Nix direnv stanza) and run `direnv allow` from a terminal.  The
+  Emacs `envrc` minor mode is enabled globally so buffers pick up the sandboxed
+  toolchains automatically.
+* **Forge** – configure Magit Forge credentials the usual way (e.g. `gh auth
+  login`).  The module adds GitHub's `gh` CLI to the profile for convenience.
+
+After secrets are available, switch Home-Manager with:
+
+```sh
+home-manager switch --flake .#yourUser@yourHost
+```
+
+## Key bindings
+
+| Binding | Scope | Action |
+|---------|-------|--------|
+| `C-c ]` | global | Accept the active Copilot completion. |
+| `C-c g g` | global | Open a `gptel` chat buffer in Org mode. |
+| `C-c g e` | global | Ask `gptel` to explain the selected region. |
+| `C-c g b` | global | Summarise the current buffer with `gptel`. |
+| `C-c g r` | global | Rewrite the active region via `gptel-rewrite`. |
+| `C-c a a` | global | Open an aider session in a project-scoped `vterm`. |
+| `C-c p ]` | projectile map | Toggle `copilot-mode` for the project. |
+| `C-c p a` | projectile map | Launch aider in the project root. |
+
+The existing Xah Fly Keys leader maps remain untouched, so the new bindings are
+available even if you are using that modal layer.
+
+## AI assisted editing
+
+* **Completions** – `copilot-mode` hooks into `prog-mode`.  Use `TAB` (or
+  `C-c ]`) to accept suggestions, `C-<tab>` for word-wise and `M-<tab>` for
+  line-wise completions.
+* **Region/file analysis** – the helper commands defined in
+  `packages.el` (`crio/gptel-explain-region`,
+  `crio/gptel-review-buffer`, `crio/gptel-refactor-region`) all route through
+  `gptel` with a custom system prompt tuned for NixOS/Emacs development.  They
+  produce results in dedicated `*gptel-…*` buffers so you can keep a running
+  conversation per file.
+
+## Repo-aware chat & patching
+
+`C-c a a` (or `C-c p a`) creates a dedicated `vterm` in the current project's
+root and starts `aider --model openai/gpt-4o-mini --no-auto-commit`.  The
+buffer name includes the project, making it easy to keep multiple sessions.  A
+prefix argument lets you edit the exact aider command before launch.
+
+Inside aider you can:
+
+1. Instruct it to draft a change (`/ask`, `/plan`, etc.).
+2. Accept patches back into the repo.
+3. Run tests from the same vterm, benefiting from the project's `direnv`
+   sandbox.
+
+## Git, testing and PRs
+
+* Use `magit-status` (`SPC m` in the Xah Fly leader map or `M-x magit-status`)
+  to stage changes.  `forge` is already installed, so `#` in the status buffer
+  will create or visit the associated pull request.
+* `vterm` inherits the project sandbox, so test commands (e.g. `nix flake
+  check`, `just test`, etc.) run in the correct environment.
+* Finish by committing in Magit and pushing/raising a PR with Forge.
+
+Following this loop you can `gptel` for guidance, `aider` for patches, test in a
+sandboxed shell, and close everything out via Magit – all without leaving
+Emacs.

--- a/nix/homeModule/emacs/default.nix
+++ b/nix/homeModule/emacs/default.nix
@@ -15,7 +15,14 @@ in
   home = {
     file.".emacs".text = builtins.readFile ./init.el;
 
-    packages = [ package ] ++ (with pkgs; [ nil ]);
+    packages =
+      [ package ]
+      ++ (with pkgs; [
+        nil
+        (python3Packages.aider-chat)
+        nodejs
+        gh
+      ]);
 
     sessionVariables = {
       EDITOR = "emacsclient -c";

--- a/nix/pkdjz/mkEmacs/default.nix
+++ b/nix/pkdjz/mkEmacs/default.nix
@@ -139,11 +139,13 @@ let
   commonPackagesEl = readFile ./packages.el;
   launcherCommonEl = readFile ./selector-common.el;
   launcherStyleEl = readFile ./vertico.el;
+  syntEl = readFile ./synth.el;
 
   packagesEl = concatStringsSep "\n" [
     commonPackagesEl
     launcherCommonEl
     launcherStyleEl
+    syntEl
   ];
 
   usePackagesNames = lib.unique (parsePackagesFromUsePackage {

--- a/nix/pkdjz/mkEmacs/synth.el
+++ b/nix/pkdjz/mkEmacs/synth.el
@@ -1,0 +1,131 @@
+(defgroup crio/devloop nil
+  "CriomOS development loop helpers."
+  :group 'tools
+  :prefix "crio/")
+
+(defcustom crio/aider-default-command
+  "aider --model openai/gpt-4o-mini --no-auto-commit"
+  "Shell command used by `crio/aider-vterm' to start aider."
+  :type 'string
+  :group 'crio/devloop)
+
+(defcustom crio/gptel-system-prompt
+  "You are an expert NixOS, Emacs and systems programming pair-programmer."
+  "System prompt supplied to gptel helper commands."
+  :type 'string
+  :group 'crio/devloop)
+
+(defcustom crio/gptel-default-model "gpt-4o-mini"
+  "Default model identifier used for gptel sessions."
+  :type 'string
+  :group 'crio/devloop)
+
+(defun crio/gptel--read-api-key ()
+  "Lookup an OpenAI compatible API key for gptel.
+The function first checks `OPENAI_API_KEY' and then pass entry
+`openai/api-key' for backwards compatibility."
+  (or (getenv "OPENAI_API_KEY")
+      (ignore-errors
+        (when (fboundp 'auth-source-pass-get)
+          (or (auth-source-pass-get "token" "openai/api-key")
+              (auth-source-pass-get "password" "openai/api-key"))))))
+
+(use-package copilot
+  :hook (prog-mode . copilot-mode)
+  :bind (:map copilot-completion-map
+              ("<tab>" . copilot-accept-completion)
+              ("TAB" . copilot-accept-completion)
+              ("C-<tab>" . copilot-accept-completion-by-word)
+              ("M-<tab>" . copilot-accept-completion-by-line))
+  :init
+  (setq copilot-disable-predicates '(copilot--buffer-changed-p))
+  :config
+  (setq copilot-node-executable (or (executable-find "node")
+                                    copilot-node-executable))
+  (define-key global-map (kbd "C-c ]") #'copilot-accept-completion)
+  (with-eval-after-load 'company
+    (define-key company-active-map (kbd "<tab>") nil)
+    (define-key company-active-map (kbd "TAB") nil))
+  (with-eval-after-load 'projectile
+    (define-key projectile-command-map (kbd "]") #'copilot-mode)))
+
+(use-package gptel
+  :commands (gptel gptel-send gptel-rewrite gptel-menu)
+  :custom
+  (gptel-default-mode 'org-mode)
+  (gptel-use-curl t)
+  :init
+  (setq gptel-model crio/gptel-default-model)
+  :config
+  (let ((backend
+         (gptel-make-openai "openai"
+           :key #'crio/gptel--read-api-key
+           :models (list crio/gptel-default-model "gpt-4o" "gpt-4o-mini"))))
+    (setq gptel-backend backend)
+    (setq gptel-default-backend backend))
+  (defun crio/gptel--ensure-buffer (name)
+    (let ((buffer (get-buffer-create name)))
+      (with-current-buffer buffer
+        (unless (derived-mode-p 'gptel-mode)
+          (gptel-mode))
+        (setq-local gptel-system-prompt crio/gptel-system-prompt)
+        (setq-local gptel-model crio/gptel-default-model))
+      buffer))
+  (defun crio/gptel-explain-region (beg end)
+    "Explain the region between BEG and END in a dedicated gptel buffer."
+    (interactive "r")
+    (let* ((code (buffer-substring-no-properties beg end))
+           (mode major-mode)
+           (buffer (crio/gptel--ensure-buffer "*gptel-explain*"))
+           (prompt (format "Explain the following %s code. Include intent, key APIs and follow-up ideas.\n\n```%s\n%s\n```"
+                           mode mode code)))
+      (gptel-request prompt
+        :buffer buffer
+        :system crio/gptel-system-prompt
+        :model crio/gptel-default-model)))
+  (defun crio/gptel-review-buffer ()
+    "Summarise the current buffer using gptel."
+    (interactive)
+    (crio/gptel-explain-region (point-min) (point-max)))
+  (defun crio/gptel-refactor-region (beg end instruction)
+    "Ask gptel to rewrite region BEG..END according to INSTRUCTION."
+    (interactive "r\nsRewrite instructions: ")
+    (gptel-rewrite beg end instruction))
+  (define-key global-map (kbd "C-c g g") #'gptel)
+  (define-key global-map (kbd "C-c g e") #'crio/gptel-explain-region)
+  (define-key global-map (kbd "C-c g b") #'crio/gptel-review-buffer)
+  (define-key global-map (kbd "C-c g r") #'crio/gptel-refactor-region))
+
+(use-package vterm
+  :commands (vterm)
+  :config
+  (setq vterm-max-scrollback 10000)
+  (defun crio/aider--project-root ()
+    (cond
+     ((and (boundp 'projectile-mode) projectile-mode (fboundp 'projectile-project-p)
+           (projectile-project-p))
+      (projectile-project-root))
+     ((fboundp 'project-current)
+      (when-let ((project (project-current)))
+        (project-root project)))
+     (t default-directory)))
+  (defun crio/aider-vterm (&optional command)
+    "Open a vterm running aider in the project root.
+With prefix argument prompt for COMMAND, otherwise use
+`crio/aider-default-command'."
+    (interactive
+     (list (when current-prefix-arg
+             (read-shell-command "Aider command: " crio/aider-default-command))))
+    (let* ((root (or (crio/aider--project-root) default-directory))
+           (default-directory root)
+           (buffer-name (format "*aider:%s*"
+                                (file-name-nondirectory (directory-file-name root))))
+           (cmd (or command crio/aider-default-command)))
+      (vterm buffer-name)
+      (vterm-send-string cmd)
+      (vterm-send-return)))
+  (define-key global-map (kbd "C-c a a") #'crio/aider-vterm)
+  (with-eval-after-load 'projectile
+    (define-key projectile-command-map (kbd "a") #'crio/aider-vterm)))
+
+(provide 'crio-synth)


### PR DESCRIPTION
## Summary
- move the Codex-style Emacs helpers into a dedicated `synth.el`
- wire the new file into the mkEmacs builder so it is loaded with the rest of the config

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68eaae2a6eb483269ba2ff6a6d8f6941